### PR TITLE
Use `ffi.errno`

### DIFF
--- a/rawterm.lua
+++ b/rawterm.lua
@@ -71,8 +71,6 @@ ffi.cdef [[
     int ioctl (int __fd, unsigned long int __request, ...);
 
     char *strerror(int errnum);
-
-    int errno;
 ]]
 
 local iflags = {
@@ -164,7 +162,7 @@ local STDIN_FILENO = 0
 local STDOUT_FILENO = 1
 
 local function die(cause)
-    local errMsg = ffi.string(C.strerror(C.errno))
+    local errMsg = ffi.string(C.strerror(ffi.errno()))
     error(cause .. " : " .. errMsg, 2)
 end
 


### PR DESCRIPTION
Take a look at https://luajit.org/ext_ffi_api.html (section `Utility Functions`) for what `ffi.errno` does :3

Reason for change:
IEEE standard does not provide guarantee that `errno` is an actual linkable symbol

From https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html

The symbol errno shall expand to a modifiable lvalue of type int. **It is unspecified whether errno is a macro or an identifier declared with external linkage.** If a macro definition is suppressed in order to access an actual object, or a program defines an identifier with the name errno, the behavior is undefined.